### PR TITLE
Fixed issue with UniqueList and portals creation

### DIFF
--- a/src/gl/scene/gl_scene.cpp
+++ b/src/gl/scene/gl_scene.cpp
@@ -104,7 +104,7 @@ angle_t GLSceneDrawer::FrustumAngle()
 {
 	float tilt = fabs(GLRenderer->mAngles.Pitch.Degrees);
 
-	// If the pitch is larger than this you can look all around at a FOV of 90°
+	// If the pitch is larger than this you can look all around at a FOV of 90ï¿½
 	if (tilt > 46.0f) return 0xffffffff;
 
 	// ok, this is a gross hack that barely works...
@@ -810,9 +810,6 @@ void GLSceneDrawer::SetFixedColormap (player_t *player)
 sector_t * GLSceneDrawer::RenderViewpoint (AActor * camera, GL_IRECT * bounds, float fov, float ratio, float fovratio, bool mainview, bool toscreen)
 {       
 	sector_t * lviewsector;
-	GLRenderer->mSceneClearColor[0] = 0.0f;
-	GLRenderer->mSceneClearColor[1] = 0.0f;
-	GLRenderer->mSceneClearColor[2] = 0.0f;
 	R_SetupFrame (r_viewpoint, r_viewwindow, camera);
 	SetViewArea();
 

--- a/src/gl/scene/gl_scene.cpp
+++ b/src/gl/scene/gl_scene.cpp
@@ -104,7 +104,7 @@ angle_t GLSceneDrawer::FrustumAngle()
 {
 	float tilt = fabs(GLRenderer->mAngles.Pitch.Degrees);
 
-	// If the pitch is larger than this you can look all around at a FOV of 90�
+	// If the pitch is larger than this you can look all around at a FOV of 90°
 	if (tilt > 46.0f) return 0xffffffff;
 
 	// ok, this is a gross hack that barely works...

--- a/src/gl/scene/gl_skydome.cpp
+++ b/src/gl/scene/gl_skydome.cpp
@@ -78,12 +78,13 @@
 
 //-----------------------------------------------------------------------------
 //
-// Shamelessly lifted from Doomsday (written by Jaakko Keränen)
+// Shamelessly lifted from Doomsday (written by Jaakko Kerï¿½nen)
 // also shamelessly lifted from ZDoomGL! ;)
 //
 //-----------------------------------------------------------------------------
 
 CVAR(Float, skyoffset, 0, 0)	// for testing
+CVAR(Bool, gl_skydome, true, CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
 
 //-----------------------------------------------------------------------------
 //
@@ -499,6 +500,15 @@ static void RenderBox(FTextureID texno, FMaterial * gltex, float x_offset, bool 
 //-----------------------------------------------------------------------------
 void GLSkyPortal::DrawContents()
 {
+	if (origin->texture[0])
+	{
+		PalEntry pe = origin->texture[0]->tex->GetSkyCapColor(false);
+		GLRenderer->mSceneClearColor[0] = pe.r / 255.f;
+		GLRenderer->mSceneClearColor[1] = pe.g / 255.f;
+		GLRenderer->mSceneClearColor[2] = pe.b / 255.f;
+	}
+	if (!gl_skydome) return;
+	
 	bool drawBoth = false;
 
 	// We have no use for Doom lighting special handling here, so disable it for this function.

--- a/src/gl/scene/gl_skydome.cpp
+++ b/src/gl/scene/gl_skydome.cpp
@@ -78,7 +78,7 @@
 
 //-----------------------------------------------------------------------------
 //
-// Shamelessly lifted from Doomsday (written by Jaakko Ker�nen)
+// Shamelessly lifted from Doomsday (written by Jaakko Keränen)
 // also shamelessly lifted from ZDoomGL! ;)
 //
 //-----------------------------------------------------------------------------

--- a/src/gl/utility/gl_templates.h
+++ b/src/gl/utility/gl_templates.h
@@ -61,7 +61,7 @@ public:
 			if (!memcmp(t, Array[i], sizeof(T))) return Array[i];
 		}
 		T * newo=TheFreeList.GetNew();
-
+		memset(newo, 0, sizeof(T));
 		*newo=*t;
 		Array.Push(newo);
 		return newo;

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -1923,6 +1923,7 @@ DSPLYMNU_GPUSWITCH				= "Notebook Switchable GPU";
 DSPLYMNU_CUSTOMINVERTMAP		= "Custom Inverse Map";
 DSPLYMNU_CUSTOMINVERTC1			= "Custom Inverse Color Dark";
 DSPLYMNU_CUSTOMINVERTC2			= "Custom Inverse Color Light";
+DSPLYMNU_RENDERSKYDOME			= "Render the skydome";
 
 // HUD Options
 HUDMNU_TITLE					= "HUD Options";

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -942,6 +942,7 @@ OptionMenu "VideoOptions" protected
 	Option "$DSPLYMNU_TELEZOOM",				"telezoom", "OnOff"
 	Slider "$DSPLYMNU_QUAKEINTENSITY",			"r_quakeintensity", 0.0, 1.0, 0.05, 2
 	Option "$DSPLYMNU_NOMONSTERINTERPOLATION",	"nomonsterinterpolation", "NoYes"
+	Option "$DSPLYMNU_RENDERSKYDOME",			"gl_skydome", "YesNo"
 }
 
 


### PR DESCRIPTION
- fixed issue with UniqueList
Added memset after creation of new pointer. This was causing massive drop of framerate on Oculus Quest (Android) when looking outside, with multiple GLSkyInfo object created, memcmp always failed with return -1 when dealing with GLSkyInfo
- added option to switch on/off the skydome in display options
- when the skydome is disabled the background color will match the color of the texture of the skydome to keep some immersion during gameplay