### PR TITLE
add console command to reset a CVAR to default value

### DIFF
--- a/src/c_cvars.cpp
+++ b/src/c_cvars.cpp
@@ -1895,6 +1895,26 @@ CCMD (unset)
 	}
 }
 
+CCMD (resetcvar)
+{
+	if (argv.argc() != 2)
+	{
+		Printf ("usage: resetcvar <variable>\n");
+	}
+	else
+	{
+		FBaseCVar *var = FindCVar (argv[1], NULL);
+		if (var != NULL)
+		{
+			var->ResetToDefault();
+		}
+		else
+		{
+			Printf ("No such variable: %s\n", argv[1]);
+		}
+	}
+}
+
 CCMD (get)
 {
 	FBaseCVar *var, *prev;


### PR DESCRIPTION
Rationale:
1. Now to reset a CVAR to default, the user doesn't need to remember the default value.
2. If a modder wants to reset a CVAR via menu command, they don't need to keep menudef and cvarinfo in sync.

https://github.com/coelckers/gzdoom/commit/18a8fafd7d3b593f672a3d29aaf711d25ca79531
https://github.com/coelckers/gzdoom/commit/92d68d05db5340f42f7b04f97ff3f33a2196f7e8

Co-authored-by: Alexander <mmaulwurff@gmail.com>