### PR TITLE
- fixed crash when cmap is null, prevent access violation exception

### DIFF
--- a/src/gl/renderer/gl_lightdata.cpp
+++ b/src/gl/renderer/gl_lightdata.cpp
@@ -467,7 +467,7 @@ void gl_SetFog(int lightlevel, int rellight, bool fullbright, const FColormap *c
 	}
 	else
 	{
-		if ((glset.lightmode == 2 || (glset.lightmode >= 8 && cmap && cmap->BlendFactor > 0)) && fogcolor == 0)
+		if (cmap && (glset.lightmode == 2 || (glset.lightmode >= 8 && cmap->BlendFactor > 0)) && fogcolor == 0)
 		{
 			float light = gl_CalcLightLevel(lightlevel, rellight, false, cmap->BlendFactor);
 			gl_SetShaderLight(light, lightlevel);


### PR DESCRIPTION
The checking for null pointer should have priority since the pointer is used in the condition block.