### PR TITLE
- Moved NRFTL before DOOM 2: Hell on Earth

### DIFF
--- a/wadsrc_extra/static/iwadinfo.txt
+++ b/wadsrc_extra/static/iwadinfo.txt
@@ -538,23 +538,9 @@ IWad
 
 IWad
 {
-	Name = "DOOM 2: Hell on Earth"
-	Autoname = "doom.id.doom2.commercial"
-	Game = "Doom"
-	Config = "Doom"
-	IWADName = "doom2.wad", 1
-	Mapinfo = "mapinfo/doom2.txt"
-	Compatibility = "Shorttex"
-	MustContain = "MAP01", "MAP30"
-	BannerColors = "a8 00 00", "a8 a8 a8"
-}
-
-// NRFTL must be last to be checked because MAP01 is its only requirement
-IWad
-{
 	Name = "DOOM 2: No Rest for the Living"
 	BannerColors = "a8 00 00", "a8 a8 a8"
-	MustContain = "MAP01"
+	MustContain = "MAP01", "MAPINFO"
 	Required = "DOOM 2: Hell on Earth"
 	Autoname = "doom.id.doom2.nerve"
 	Game = "Doom"
@@ -562,6 +548,20 @@ IWad
 	IWADName = "nerve.wad"
 	Mapinfo = "mapinfo/doom2.txt"
 	Compatibility = "Shorttex"
+}
+
+// Doom 2 must be last to be checked because MAP01 is its only requirement
+IWad
+{
+	Name = "DOOM 2: Hell on Earth"
+	Autoname = "doom.id.doom2.commercial"
+	Game = "Doom"
+	Config = "Doom"
+	IWADName = "doom2.wad", 1
+	Mapinfo = "mapinfo/doom2.txt"
+	Compatibility = "Shorttex"
+	MustContain = "MAP01"
+	BannerColors = "a8 00 00", "a8 a8 a8"
 }
 
 


### PR DESCRIPTION
NRFTL as last check was causing some iwad like zbloody_hell.wad to not work when doom 2 was not present in any iwadsearch directory, since it was identified like NRFTL with requirement of Doom 2 iwad.
Added MAPINFO to MustContain for NRFTL and moved before Doom 2 to keep the last iwad without Requirements and keep the original behavior