### PR TITLE
gus timidity+ and wildmidi emulation fix

### DIFF
--- a/libraries/music_common/fileio.h
+++ b/libraries/music_common/fileio.h
@@ -320,7 +320,7 @@ public:
 		std::string fullname;
 		if (!fn) 
 		{
-			f = utf8_fopen(mBaseFile.c_str(), "rt");
+			f = utf8_fopen(mBaseFile.c_str(), "rb");
 			fullname = mBaseFile;
 		}
 		else
@@ -330,11 +330,11 @@ public:
 				for(int i = (int)mPaths.size()-1; i>=0; i--)
 				{
 					fullname = mPaths[i] + fn;
-					f = utf8_fopen(fullname.c_str(), "rt");
-					break;
+					f = utf8_fopen(fullname.c_str(), "rb");
+					if (f) break;
 				}
 			}
-			if (!f) f = fopen(fn, "rt");
+			if (!f) f = fopen(fn, "rb");
 		}
 		if (!f) return nullptr;
 		auto tf = new StdioFileReader;

--- a/libraries/timidity/playmidi.cpp
+++ b/libraries/timidity/playmidi.cpp
@@ -379,7 +379,7 @@ void Renderer::start_note(int chan, int note, int vel)
 		if (ip->samples != 1 && ip->sample->type == INST_GUS)
 		{
 			printMessage(CMSG_WARNING, VERB_VERBOSE, 
-				"Strange: percussion instrument with %d samples!", ip->samples);
+				"Strange: percussion instrument with %d samples!\n", ip->samples);
 		}
 	}
 	else

--- a/libraries/timidity/timidity.cpp
+++ b/libraries/timidity/timidity.cpp
@@ -824,23 +824,28 @@ static void default_cmsg(int type, int verbosity_level, const char* fmt, ...)
 {
 	if (verbosity_level >= VERB_NOISY) return;	// Don't waste time on diagnostics.
 
+	std::string msg;
 	va_list args;
 	va_start(args, fmt);
 
 	switch (type)
 	{
 	case CMSG_ERROR:
-		vprintf("Error: %s\n", args);
+		msg = "Error: ";
 		break;
 
 	case CMSG_WARNING:
-		vprintf("Warning: %s\n", args);
+		msg = "Warning: ";
 		break;
 
 	case CMSG_INFO:
-		vprintf("Info: %s\n", args);
+		msg = "Info: ";
 		break;
 	}
+
+	msg += fmt;
+	vprintf(msg.c_str(), args);
+	va_end(args);
 }
 
 // Allow hosting applications to capture the messages and deal with them themselves.

--- a/libraries/timidityplus/common.cpp
+++ b/libraries/timidityplus/common.cpp
@@ -157,23 +157,28 @@ void default_ctl_cmsg(int type, int verbosity_level, const char* fmt, ...)
 {
 	if (verbosity_level >= VERB_DEBUG) return;	// Don't waste time on diagnostics.
 
+	std::string msg;
 	va_list args;
 	va_start(args, fmt);
 
 	switch (type)
 	{
 	case CMSG_ERROR:
-		vprintf("Error: %s\n", args);
+		msg = "Error: ";
 		break;
 
 	case CMSG_WARNING:
-		vprintf("Warning: %s\n", args);
+		msg = "Warning: ";
 		break;
 
 	case CMSG_INFO:
-		vprintf("Info: %s\n", args);
+		msg = "Info: ";
 		break;
 	}
+
+	msg += fmt;
+	vprintf(msg.c_str(), args);
+	va_end(args);
 }
 
 // Allow hosting applications to capture the messages and deal with them themselves.

--- a/libraries/wildmidi/wm_error.cpp
+++ b/libraries/wildmidi/wm_error.cpp
@@ -43,6 +43,7 @@ void _WM_ERROR_NEW(const char * wmfmt, ...) {
 	va_list args;
 	va_start(args, wmfmt);
 	wm_error_func(wmfmt, args);
+	va_end(args);
 }
 
 void _WM_ERROR(const char * func, unsigned int lne, int wmerno,

--- a/libraries/zmusic/mididevices/music_timidity_mididevice.cpp
+++ b/libraries/zmusic/mididevices/music_timidity_mididevice.cpp
@@ -94,42 +94,44 @@ protected:
 
 void TimidityMIDIDevice::LoadInstruments()
 {
-	if (gusConfig.dmxgus.size())
+	if (gusConfig.reader)
 	{
 		// Check if we got some GUS data before using it.
-		std::string ultradir = getenv("ULTRADIR");
-		if (ultradir.length() || gusConfig.gus_patchdir.length() != 0)
+		std::string ultradir;
+		const char *ret = getenv("ULTRADIR");
+		if (ret) ultradir = std::string(ret);
+		// The GUS put its patches in %ULTRADIR%/MIDI so we can try that
+		if (ultradir.length())
 		{
-			auto psreader = new MusicIO::FileSystemSoundFontReader("");
-			
-			// The GUS put its patches in %ULTRADIR%/MIDI so we can try that
-			if (ultradir.length())
-			{
-				ultradir += "/midi";
-				psreader->add_search_path(ultradir.c_str());
-			}
-			// Load DMXGUS lump and patches from gus_patchdir
-			if (gusConfig.gus_patchdir.length() != 0) psreader->add_search_path(gusConfig.gus_patchdir.c_str());
-			
-			gusConfig.instruments.reset(new Timidity::Instruments(psreader));
-			bool success = gusConfig.instruments->LoadDMXGUS(gusConfig.gus_memsize, (const char*)gusConfig.dmxgus.data(), gusConfig.dmxgus.size()) >= 0;
-			
-			gusConfig.dmxgus.clear();
-			
-			if (success)
-			{
-				gusConfig.loadedConfig = "DMXGUS";
-				return;
-			}
+			ultradir += "/midi";
+			gusConfig.reader->add_search_path(ultradir.c_str());
 		}
-		gusConfig.loadedConfig = "";
-		gusConfig.instruments.reset();
-		throw std::runtime_error("Unable to initialize DMXGUS for GUS MIDI device");
-	}
-	else if (gusConfig.reader)
-	{
-		gusConfig.loadedConfig = gusConfig.readerName;
+		// Load DMXGUS lump and patches from gus_patchdir
+		if (gusConfig.gus_patchdir.length() != 0) gusConfig.reader->add_search_path(gusConfig.gus_patchdir.c_str());
+		
 		gusConfig.instruments.reset(new Timidity::Instruments(gusConfig.reader));
+		gusConfig.loadedConfig = gusConfig.readerName;
+	}
+
+	if (gusConfig.instruments == nullptr)
+	{
+		throw std::runtime_error("No instruments set for GUS device");
+	}
+
+	if (gusConfig.gus_dmxgus && gusConfig.dmxgus.size())
+	{
+		bool success = gusConfig.instruments->LoadDMXGUS(gusConfig.gus_memsize, (const char*)gusConfig.dmxgus.data(), gusConfig.dmxgus.size()) >= 0;
+		gusConfig.reader = nullptr;
+
+		if (!success)
+		{
+			gusConfig.instruments.reset();
+			gusConfig.loadedConfig = "";
+			throw std::runtime_error("Unable to initialize DMXGUS for GUS MIDI device");
+		}
+	}
+	else
+	{
 		bool err = gusConfig.instruments->LoadConfig() < 0;
 		gusConfig.reader = nullptr;
 		
@@ -139,10 +141,6 @@ void TimidityMIDIDevice::LoadInstruments()
 			gusConfig.loadedConfig = "";
 			throw std::runtime_error("Unable to initialize instruments for GUS MIDI device");
 		}
-	}
-	else if (gusConfig.instruments == nullptr)
-	{
-		throw std::runtime_error("No instruments set for GUS device");
 	}
 }
 
@@ -257,20 +255,11 @@ void TimidityMIDIDevice::ComputeOutput(float *buffer, int len)
 
 bool GUS_SetupConfig(const char* args)
 {
-	gusConfig.reader = nullptr;
-	if ((gusConfig.gus_dmxgus && *args == 0) || !stricmp(args, "DMXGUS"))
-	{
-		if (stricmp(gusConfig.loadedConfig.c_str(), "DMXGUS") == 0) return false; // aleady loaded
-		if (gusConfig.dmxgus.size() > 0)
-		{
-			gusConfig.readerName = "DMXGUS";
-			return true;
-		}
-	}
 	if (*args == 0) args = gusConfig.gus_config.c_str();
-	if (stricmp(gusConfig.loadedConfig.c_str(), args) == 0) return false; // aleady loaded
+	if (gusConfig.gus_dmxgus && *args == 0) args = "DMXGUS";
+	//if (stricmp(gusConfig.loadedConfig.c_str(), args) == 0) return false; // aleady loaded
 
-	MusicIO::SoundFontReaderInterface* reader = MusicIO::ClientOpenSoundFont(args, SF_GUS | SF_SF2);
+	MusicIO::SoundFontReaderInterface* reader = MusicIO::ClientOpenSoundFont(args, SF_GUS);
 	if (!reader && MusicIO::fileExists(args))
 	{
 		auto f = MusicIO::utf8_fopen(args, "rb");
@@ -284,6 +273,11 @@ bool GUS_SetupConfig(const char* args)
 				reader = new MusicIO::SF2Reader(args);
 		}
 		if (!reader) reader = new MusicIO::FileSystemSoundFontReader(args, true);
+	}
+
+	if (!reader && gusConfig.gus_dmxgus)
+	{
+		reader = new MusicIO::FileSystemSoundFontReader(args, true);
 	}
 
 	if (reader == nullptr)

--- a/libraries/zmusic/mididevices/music_wildmidi_mididevice.cpp
+++ b/libraries/zmusic/mididevices/music_wildmidi_mididevice.cpp
@@ -87,15 +87,7 @@ void WildMIDIDevice::LoadInstruments()
 	{
 		wildMidiConfig.loadedConfig = wildMidiConfig.readerName;
 		wildMidiConfig.instruments.reset(new WildMidi::Instruments(wildMidiConfig.reader, SampleRate));
-		int error = wildMidiConfig.instruments->LoadConfig(wildMidiConfig.readerName.c_str());
 		wildMidiConfig.reader = nullptr;
-
-		if (error)
-		{
-			wildMidiConfig.instruments.reset();
-			wildMidiConfig.loadedConfig = "";
-			throw std::runtime_error("Unable to initialize instruments for WildMidi device");
-		}
 	}
 	else if (wildMidiConfig.instruments == nullptr)
 	{
@@ -104,7 +96,9 @@ void WildMIDIDevice::LoadInstruments()
 	instruments = wildMidiConfig.instruments;
 	if (instruments->LoadConfig(nullptr) < 0)
 	{
-		throw std::runtime_error("Unable to load instruments set for WildMidi device");
+		wildMidiConfig.instruments.reset();
+		wildMidiConfig.loadedConfig = "";
+		throw std::runtime_error("Unable to initialize instruments for WildMidi device");
 	}
 }
 

--- a/libraries/zmusic/zmusic/configuration.cpp
+++ b/libraries/zmusic/zmusic/configuration.cpp
@@ -797,7 +797,7 @@ DLL_EXPORT bool ChangeMusicSettingString(EStringConfigKey key, MusInfo* currSong
 			
 		case zmusic_gus_patchdir:
 			gusConfig.gus_patchdir = value;
-			return devType() == MDEV_GUS && gusConfig.gus_dmxgus;
+			return devType() == MDEV_GUS;
 
 		case zmusic_timidity_config:
 			timidityConfig.timidity_config = value;

--- a/libraries/zmusic/zmusic/configuration.cpp
+++ b/libraries/zmusic/zmusic/configuration.cpp
@@ -479,15 +479,15 @@ DLL_EXPORT bool ChangeMusicSettingInt(EIntConfigKey key, MusInfo *currSong, int 
 
 		case zmusic_timidity_reverb:
 			if (value < 0 || value > 4) value = 0;
-			else TimidityPlus_SetReverb();
 			local_timidity_reverb = value;
+			TimidityPlus_SetReverb();
 			if (pRealValue) *pRealValue = value;
 			return false;
 
 		case zmusic_timidity_reverb_level:
 			if (value < 0 || value > 127) value = 0;
-			else TimidityPlus_SetReverb();
 			local_timidity_reverb_level = value;
+			TimidityPlus_SetReverb();
 			if (pRealValue) *pRealValue = value;
 			return false;
 

--- a/src/fragglescript/t_parse.cpp
+++ b/src/fragglescript/t_parse.cpp
@@ -735,6 +735,7 @@ void script_error(const char *s, ...)
 	va_list args;
 	va_start(args, s);
 	composed.VFormat(s, args);
+	va_end(args);
 	throw CFsError(composed);
 }
 

--- a/src/menu/menudef.cpp
+++ b/src/menu/menudef.cpp
@@ -1519,7 +1519,7 @@ static void InitMusicMenus()
 {
 	DMenuDescriptor **advmenu = MenuDescriptors.CheckKey("AdvSoundOptions");
 	auto soundfonts = sfmanager.GetList();
-	std::tuple<const char *, int, const char *> sfmenus[] = { std::make_tuple("GusConfigMenu", SF_SF2 | SF_GUS, "midi_config"),
+	std::tuple<const char *, int, const char *> sfmenus[] = { std::make_tuple("GusConfigMenu", SF_GUS, "midi_config"),
 																std::make_tuple("WildMidiConfigMenu", SF_GUS, "wildmidi_config"),
 																std::make_tuple("TimidityConfigMenu", SF_SF2 | SF_GUS, "timidity_config"),
 																std::make_tuple("FluidPatchsetMenu", SF_SF2, "fluid_patchset"),

--- a/src/scripting/vm/vmframe.cpp
+++ b/src/scripting/vm/vmframe.cpp
@@ -689,8 +689,9 @@ void ThrowAbortException(EVMAbortException reason, const char *moreinfo, ...)
 {
 	va_list ap;
 	va_start(ap, moreinfo);
-	throw CVMAbortException(reason, moreinfo, ap);
+	CVMAbortException err(reason, moreinfo, ap);
 	va_end(ap);
+	throw err;
 }
 
 void ThrowAbortException(VMScriptFunction *sfunc, VMOP *line, EVMAbortException reason, const char *moreinfo, ...)
@@ -699,10 +700,10 @@ void ThrowAbortException(VMScriptFunction *sfunc, VMOP *line, EVMAbortException 
 	va_start(ap, moreinfo);
 
 	CVMAbortException err(reason, moreinfo, ap);
+	va_end(ap);
 
 	err.stacktrace.AppendFormat("Called from %s at %s, line %d\n", sfunc->PrintableName.GetChars(), sfunc->SourceFileName.GetChars(), sfunc->PCToLine(line));
 	throw err;
-	va_end(ap);
 }
 
 DEFINE_ACTION_FUNCTION(DObject, ThrowAbortException)

--- a/src/sound/music/i_music.cpp
+++ b/src/sound/music/i_music.cpp
@@ -258,7 +258,8 @@ static void SetupWgOpn()
 
 static void SetupDMXGUS()
 {
-	int lump = Wads.CheckNumForFullName("DMXGUS");
+	int lump = Wads.CheckNumForName("DMXGUSC", ns_global);
+	if (lump < 0) lump = Wads.CheckNumForName("DMXGUS", ns_global);
 	if (lump < 0)
 	{
 		return;

--- a/src/sound/music/i_soundfont.cpp
+++ b/src/sound/music/i_soundfont.cpp
@@ -195,6 +195,7 @@ FileReader FSF2Reader::OpenFile(const char *name)
 
 FZipPatReader::FZipPatReader(const char *filename)
 {
+	mAllowAbsolutePaths = true;
 	resf = FResourceFile::OpenResourceFile(filename, true);
 }
 
@@ -219,6 +220,7 @@ FileReader FZipPatReader::OpenFile(const char *name)
 			return lump->NewReader();
 		}
 	}
+	fr.OpenFile(name);
 	return fr;
 }
 
@@ -479,13 +481,6 @@ FSoundFontReader *FSoundFontManager::OpenSoundFont(const char *name, int allowed
 		}
 	}
 
-	auto sfi = FindSoundFont(name, allowed);
-	if (sfi != nullptr)
-	{
-		if (sfi->type == SF_SF2) return new FSF2Reader(sfi->mFilename);
-		else return new FZipPatReader(sfi->mFilename);
-	}
-	// The sound font collection did not yield any good results.
 	// Next check if the file is a .sf file
 	if (allowed & SF_SF2)
 	{
@@ -501,6 +496,7 @@ FSoundFontReader *FSoundFontManager::OpenSoundFont(const char *name, int allowed
 			}
 		}
 	}
+	// Next check if the file is a resource file (it should contains gus patches and a timidity.cfg file)
 	if (allowed & SF_GUS)
 	{
 		FileReader fr;
@@ -523,6 +519,13 @@ FSoundFontReader *FSoundFontManager::OpenSoundFont(const char *name, int allowed
 		{
 			return new FPatchSetReader(name);
 		}
+	}
+	// Lastly check in the sound font collection for a specific item or pick the first valid item available.
+	auto sfi = FindSoundFont(name, allowed);
+	if (sfi != nullptr)
+	{
+		if (sfi->type == SF_SF2) return new FSF2Reader(sfi->mFilename);
+		else return new FZipPatReader(sfi->mFilename);
 	}
 	return nullptr;
 

--- a/src/sound/music/music_config.cpp
+++ b/src/sound/music/music_config.cpp
@@ -267,7 +267,7 @@ CUSTOM_CVAR(String, opn_custom_bank, "", CVAR_ARCHIVE | CVAR_VIRTUAL)
 //==========================================================================
 
 
-CUSTOM_CVAR(String, midi_config, GAMENAMELOWERCASE, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
+CUSTOM_CVAR(String, midi_config, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
 {
 	FORWARD_STRING_CVAR(gus_config);
 }

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2083,7 +2083,7 @@ OptionMenu ModReplayerOptions protected
 	Title "$ADVSNDMNU_TIMIDITY"
 	LabeledSubMenu "$ADVSNDMNU_SELCONFIG",		"timidity_config", "TimidityConfigMenu"
 	Option "$ADVSNDMNU_REVERB", 			"timidity_reverb", "TimidityReverb"
-	Slider "$ADVSNDMNU_REVERB_LEVEL", 		"timidity_reverb_level", 9, 127, 1, 0
+	Slider "$ADVSNDMNU_REVERB_LEVEL", 		"timidity_reverb_level", 0, 127, 1, 0
 	Option "$ADVSNDMNU_CHORUS", 			"timidity_chorus", "OnOff"
 	// other CVARs need to be revieved for usefulness
  }


### PR DESCRIPTION
Fixes for gus, timidity+ and wildmidi emulation
- fixed gus emulation not working with `DMXGUS` and `DMXGUSC` lump
- `gus_patchdir` and/or `ULTRADIR` variable can be used to load custom gus patches together with main patches set with `midi_config` (not required when using DMXGUS(C) lump configuration)
- fixed wildmidi emulation not working with collection of GUS patches (resource files)
- `gus_patchdir` and `ULTRADIR` variable can be used whether DMXGUS or timidity configuration is used
- removed sf2 files from midi_config items for gus emulation (when using sf2 with gus emulation the sound is distorted), only resource files will be listed to be used with gus emulation.
- fixed `SetupDMXGUS` not loading lump correctly, wrong use of CheckNumForFullName, both DMXGUS and DMXGUSC will be recognized correctly
- added absolute paths to `FZipPatReader` so we can add custom patches along with the patches present in the resource file by using `gus_patchdir` and/or `ULTRADIR` variable (some custom maps has custom patches that can be added this way without putting them inside the resource file or in the same folder of the configuration file)
- `midi_config` default to empty string, since `lzdoom.sf2` doesn't seem supported (distorted sound)
- fixed missing va_end macro in some functions
- changed the order in which the configuration is read; the value of `midi_config`, `wildmidi_config` and `timidity_config` has precedence over the SoundFont collection built by SoundfontSearch.Directories. Now is possible to point the config property to a timidity configuration file inside a folder with GUS patches without it being overridden by the first valid SoundFont from the collection.
- fixed timidity and timidityplus `default_cmsg` and `default_ctl_cmsg` wrong use of `vprintf` causing access violation exception in some scenario
- when opening a file with FileSystemSoundFontReader only the last path added to the reader was used, but we can actually add up to two path by setting both `gus_pathdir` and the variable `ULTRADIR`.

To properly test the DMXGUS configuration the `gus_memsize` can be tweaked so the sound will listen differently depending on the memory selected (256 / unlimited sounds way different).

Also to test the `midi_config` and `wildmidi_config` is better to remove paths from the section `SoundfontSearch.Directories` since a valid item is picked from the collection if no value has been set for these options.

A good example of custom `DMXGUSC` lump with custom patches is the map d2xtreme, where the music will sound quiet different whether you use the lump as configuration or the fallback timidity configuration
https://www.doomworld.com/idgames/levels/doom2/d-f/d2xtreme