### PR TITLE
- fixed fluidsynth settings getting reset to default on init

### DIFF
--- a/libraries/zmusic/mididevices/music_fluidsynth_mididevice.cpp
+++ b/libraries/zmusic/mididevices/music_fluidsynth_mididevice.cpp
@@ -259,7 +259,8 @@ FluidSynthMIDIDevice::~FluidSynthMIDIDevice()
 
 int FluidSynthMIDIDevice::OpenRenderer()
 {
-	fluid_synth_system_reset(FluidSynth);
+	// Send MIDI system reset command (big red 'panic' button), turns off notes, resets controllers and restores initial basic channel configuration.
+	//fluid_synth_system_reset(FluidSynth);
 	return 0;
 }
 

--- a/libraries/zmusic/zmusic/configuration.cpp
+++ b/libraries/zmusic/zmusic/configuration.cpp
@@ -686,8 +686,8 @@ DLL_EXPORT bool ChangeMusicSettingFloat(EFloatConfigKey key, MusInfo* currSong, 
 		case zmusic_fluid_chorus_level:
 			if (value < 0)
 				value = 0;
-			else if (value > 1)
-				value = 1;
+			else if (value > 10)
+				value = 10;
 
 			if (currSong != NULL)
 				currSong->ChangeSettingNum("fluidsynth.z.chorus", value);


### PR DESCRIPTION
- the reset in OpenRenderer reset all the settings to fluidsynth initial default values preventing any customization to be applied on startup, also because there is no chorus or reverb advanced options available in the menu, fluid_synth_set_chorus is never executed again and so the custom settings defined in lzdoom are never used.

I frankly don't know why there was the need of executing the fluid_synth_system_reset during initialization but I didn't notice any issues after removing it.

lzdoom (gzdoom) fluidsynth settings have been customized by using the following recommendation
https://forums.scummvm.org/viewtopic.php?p=72972&sid=d139e99a13359541ead07073112e3888#72972
f45c6247693e735298e6b5657ae8f15ed794055f